### PR TITLE
add comment attachment call to preserve comments on ast

### DIFF
--- a/src/parser-engine.ts
+++ b/src/parser-engine.ts
@@ -229,7 +229,7 @@ export class ParserEngine {
 		let ast = null;
 
 		try {
-			ast = esprima.parse(inputSourceCode); //, { raw: true, tokens: true, range: true, comment: true });
+			ast = esprima.parse(inputSourceCode, { range: true, comment: true, tokens: true });
 		}
 		catch(error) {
 			console.log("Unable to parse file:", filename);
@@ -244,6 +244,12 @@ export class ParserEngine {
 		});
 
 		let option = { comment: true, format: { compact: this.compactMode,  quotes: '"' }};
+
+		if (!this.compactMode && ast && ast.comments) {
+			// manually attach comments
+			ast = escodegen.attachComments(ast, ast.comments, ast.tokens);
+		}
+
 		let finalSource = escodegen.generate(ast, option);
 
 		try {

--- a/src/parser-engine.ts
+++ b/src/parser-engine.ts
@@ -230,6 +230,10 @@ export class ParserEngine {
 
 		try {
 			ast = esprima.parse(inputSourceCode, { range: true, comment: true, tokens: true });
+			if (!this.compactMode && ast && ast.comments) {
+				// manually attach comments
+				ast = escodegen.attachComments(ast, ast.comments, ast.tokens);
+			}
 		}
 		catch(error) {
 			console.log("Unable to parse file:", filename);
@@ -244,11 +248,6 @@ export class ParserEngine {
 		});
 
 		let option = { comment: true, format: { compact: this.compactMode,  quotes: '"' }};
-
-		if (!this.compactMode && ast && ast.comments) {
-			// manually attach comments
-			ast = escodegen.attachComments(ast, ast.comments, ast.tokens);
-		}
 
 		let finalSource = escodegen.generate(ast, option);
 


### PR DESCRIPTION
This was a fix so that I can use tspath with comment-based sourcemaps generated prior to running tspath
Not sure the main project is being maintained, so I've been using your fork.